### PR TITLE
Fixed issue with php-fpm not starting

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,10 +1,30 @@
 #!/bin/bash
 
-# Get the current PHP version
+# Start NGINX 
+/etc/init.d/nginx start
+
+# Start PHP-FPM (any PHP version)
 current_version=$(php --version | head -n 1 | cut -d " " -f 2 | cut -c 1,3)
 formatted_version=${current_version:0:1}.${current_version:1:2}
 
-/etc/init.d/nginx start
-cp -rf /etc/init.d/php${formatted_version}-fpm /etc/init.d/php-fpm 
-/etc/init.d/php-fpm start
-tail -f /var/log/nginx/access.log /var/log/nginx/error.log /var/www/default/storage/logs/laravel.log
+if [ -f "/etc/init.d/php${formatted_version}-fpm" ]; then
+    cp -rf /etc/init.d/php${formatted_version}-fpm /etc/init.d/php-fpm 
+fi
+
+if [ -f "/etc/init.d/php-fpm" ]; then
+    /etc/init.d/php-fpm start
+fi
+
+# Tail on Logs that exist
+nginx_access="/var/log/nginx/access.log"
+nginx_error="/var/log/nginx/error.log"
+laravel_log="/var/www/default/storage/logs/laravel.log"
+lumen_log="/var/www/default/storage/logs/lumen.log"
+
+for log in "$nginx_access" "$nginx_error" "$laravel_log" "$lumen_log"; do
+    if [ -f "$log" ]; then
+	    arr+=("$log")
+    fi
+done
+
+sudo tail -f "${arr[@]}"

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# Get the current PHP version
+current_version=$(php --version | head -n 1 | cut -d " " -f 2 | cut -c 1,3)
+formatted_version=${current_version:0:1}.${current_version:1:2}
+
 /etc/init.d/nginx start
+cp -rf /etc/init.d/php${formatted_version}-fpm /etc/init.d/php-fpm 
 /etc/init.d/php-fpm start
 tail -f /var/log/nginx/access.log /var/log/nginx/error.log /var/www/default/storage/logs/laravel.log

--- a/run.sh
+++ b/run.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 
-# Start NGINX 
-/etc/init.d/nginx start
+# Start NGINX if it exists
+if [ -f "/etc/init.d/nginx" ]; then
+    /etc/init.d/nginx start
+fi
 
-# Start PHP-FPM (any PHP version)
+# Start PHP-FPM (any PHP version) if it exists
 current_version=$(php --version | head -n 1 | cut -d " " -f 2 | cut -c 1,3)
 formatted_version=${current_version:0:1}.${current_version:1:2}
 


### PR DESCRIPTION
Bug report:

- php-fpm was not starting up because /etc/init.d has php7.2-fpm and not php-fpm.

Instead of renaming php7.2-fpm to php-fpm, I kept php7.2-fpm untouched and created php-fpm from grabbing the current PHP version.

Solution:

- php-fpm now starts.

If you wish to test this, I also created a Docker image after your image:

FROM ravigehlot/larasible